### PR TITLE
Add Whisper transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ Gesahni aims to provide a simple interface for converting audio to text using [W
 
 ## Running the Application
 
-After installing dependencies, run the main script with an audio file as input:
+After installing dependencies, run the main script. It will create a session
+folder for today's date inside the `sessions/` directory. Place an `audio.wav`
+file in that folder and run:
 
 ```bash
-python main.py path/to/audiofile
+python main.py
 ```
 
-The script will output the transcribed text to the console.
+The transcription will be stored as `transcript.txt` inside the same session
+folder and printed to the console.
 
 ## Contribution Guidelines
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 """Entry point for running the assistant."""
+import os
 import yaml
 from src.assistant.core import Assistant
 from src.sessions import SessionManager
@@ -17,9 +18,12 @@ def main() -> None:
     # Normally we would pass config to components.
     print(f"Loaded config for {config.get('name')}")
     print(f"Session directory prepared at {session_dir}")
-    # Placeholder for processing
-    result = assistant.process_audio('sample.wav')
-    print(f"Processed audio: {result}")
+
+    audio_path = os.path.join(session_dir, "audio.wav")
+    transcript_path = os.path.join(session_dir, "transcript.txt")
+    result = assistant.process_audio(audio_path, transcript_path)
+    print(f"Transcription saved to {transcript_path}")
+    print(result)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openai-whisper

--- a/src/assistant/core.py
+++ b/src/assistant/core.py
@@ -7,7 +7,8 @@ class Assistant:
         self.transcription = TranscriptionService()
         self.memory = Memory()
 
-    def process_audio(self, audio_path: str) -> str:
-        text = self.transcription.transcribe(audio_path)
+    def process_audio(self, audio_path: str, transcript_path: str) -> str:
+        """Transcribe ``audio_path`` and store the result."""
+        text = self.transcription.transcribe(audio_path, transcript_path)
         self.memory.add(text)
         return text

--- a/src/transcription/base.py
+++ b/src/transcription/base.py
@@ -1,4 +1,31 @@
+import os
+
+
 class TranscriptionService:
-    """Placeholder transcription service."""
-    def transcribe(self, audio_path: str) -> str:
-        return "transcribed text"
+    """Transcription service using OpenAI Whisper."""
+
+    def __init__(self, model: str = "base") -> None:
+        """Initialize the service with a Whisper model name."""
+        self.model_name = model
+        self._model = None
+
+    def _load_model(self):
+        if self._model is None:
+            try:
+                import whisper
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Whisper is not installed. Install the 'openai-whisper' package"
+                ) from exc
+
+            self._model = whisper.load_model(self.model_name)
+
+    def transcribe(self, audio_path: str, output_path: str) -> str:
+        """Transcribe ``audio_path`` and write result to ``output_path``."""
+        self._load_model()
+        result = self._model.transcribe(audio_path)
+        text = result.get("text", "").strip()
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return text


### PR DESCRIPTION
## Summary
- add `TranscriptionService` using OpenAI Whisper and save transcripts to file
- allow `Assistant.process_audio` to specify transcript path
- update `main.py` to read/write from today's session folder
- document new workflow in README
- add `openai-whisper` requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687100ae8eb0832aaa8d4abfffe0d2f8