### PR TITLE
Add configurable audio and session settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ python main.py path/to/audiofile
 
 The script will output the transcribed text to the console.
 
+## Configuration
+
+Runtime options are stored in `config.yaml`. The file includes settings for
+audio recording parameters, the Whisper model to load, and the directory used
+for session data. Adjust these values to customize how the assistant operates.
+
 ### Web Interface
 
 The project also includes a minimal web interface for recording video with audio.

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,13 @@
 # Default configuration for the assistant
 name: example-assistant
+
+# Audio recording parameters
+audio:
+  bitrate: 128k
+  format: wav
+
+# Whisper model used for transcription
+whisper_model: base
+
+# Directory where session data is stored
+session_root: sessions

--- a/main.py
+++ b/main.py
@@ -11,11 +11,21 @@ def load_config(path: str) -> dict:
 
 def main() -> None:
     config = load_config('config.yaml')
-    assistant = Assistant()
-    session_manager = SessionManager()
+
+    assistant = Assistant(model_name=config.get('whisper_model', 'base'))
+
+    session_manager = SessionManager(
+        root=config.get('session_root', 'sessions')
+    )
     session_dir = session_manager.create_today_session()
-    # Normally we would pass config to components.
+
     print(f"Loaded config for {config.get('name')}")
+    audio_cfg = config.get('audio', {})
+    print(
+        f"Audio settings: bitrate={audio_cfg.get('bitrate')} "
+        f"format={audio_cfg.get('format')}"
+    )
+    print(f"Using Whisper model: {config.get('whisper_model')}")
     print(f"Session directory prepared at {session_dir}")
     # Placeholder for processing
     result = assistant.process_audio('sample.wav')

--- a/server.py
+++ b/server.py
@@ -2,11 +2,20 @@ from flask import Flask, request, jsonify, render_template
 import tempfile
 import subprocess
 from pathlib import Path
+import yaml
 
 from src.transcription.base import TranscriptionService
 
+
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+config = load_config("config.yaml")
+transcriber = TranscriptionService(config.get("whisper_model", "base"))
+
 app = Flask(__name__)
-transcriber = TranscriptionService()
 
 @app.route('/')
 def index():

--- a/src/assistant/core.py
+++ b/src/assistant/core.py
@@ -3,8 +3,10 @@ from src.memory.memory import Memory
 
 class Assistant:
     """Main assistant class coordinating subsystems."""
-    def __init__(self):
-        self.transcription = TranscriptionService()
+
+    def __init__(self, model_name: str = "base"):
+        """Initialize the assistant with the given Whisper model."""
+        self.transcription = TranscriptionService(model_name)
         self.memory = Memory()
 
     def process_audio(self, audio_path: str) -> str:


### PR DESCRIPTION
## Summary
- extend `config.yaml` with audio, whisper model and session root options
- inject whisper model and session root into `Assistant`, `SessionManager`, and Flask server
- show loaded configuration details in `main.py`
- document configuration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871031b9a24832a964b0b6cd34084af