### PR TITLE
Ensure session directory is current for each request

### DIFF
--- a/server.py
+++ b/server.py
@@ -45,6 +45,14 @@ def index():
 
 @app.route('/transcribe', methods=['POST'])
 def transcribe_route():
+    global SESSION_DIR
+    try:
+        new_path = Path(session_manager.create_today_session())
+        if new_path != SESSION_DIR:
+            SESSION_DIR = new_path
+    except Exception as exc:
+        logger.exception("Failed to ensure session directory: %s", exc)
+
     if 'file' not in request.files:
         logger.warning("No file provided in request")
         return jsonify({'error': 'missing file'}), 400
@@ -102,6 +110,14 @@ def transcribe_route():
 @app.route('/upload', methods=['POST'])
 def upload_chunk():
     """Handle streaming WebM chunks from the browser."""
+    global SESSION_DIR
+    try:
+        new_path = Path(session_manager.create_today_session())
+        if new_path != SESSION_DIR:
+            SESSION_DIR = new_path
+    except Exception as exc:
+        logger.exception("Failed to ensure session directory: %s", exc)
+
     if 'file' not in request.files:
         logger.warning("No file provided in chunk upload")
         return jsonify({'error': 'missing file'}), 400


### PR DESCRIPTION
## Summary
- ensure the session directory is refreshed at the start of `/transcribe` and `/upload`

## Testing
- `python -m py_compile server.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6871c24a9eb0832ab99921d5e3bac9f8