### PR TITLE
Add tests and status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
 
+## Running Tests
+
+After installing the project dependencies, you can run the automated tests with
+
+```bash
+pytest
+```
+
+The tests exercise the Flask server using its built-in test client.
+
 ## Contribution Guidelines
 
 Contributions are welcome! To contribute:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyyaml
+pytest

--- a/server.py
+++ b/server.py
@@ -181,5 +181,20 @@ def upload_chunk():
 
     return jsonify({"text": text})
 
+@app.route("/status/latest")
+def status_latest() -> 'flask.wrappers.Response':
+    """Return the most recent transcription line."""
+    transcript_path = SESSION_DIR / "transcript.txt"
+    text = ""
+    try:
+        if transcript_path.exists():
+            lines = transcript_path.read_text(encoding="utf-8").splitlines()
+            if lines:
+                text = lines[-1]
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        logger.exception("Failed to read transcript: %s", exc)
+        return jsonify({"error": f"failed to read transcript: {exc}"}), 500
+    return jsonify({"text": text})
+
 if __name__ == "__main__":
     app.run(debug=FLASK_DEBUG)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,46 @@
+import io
+import subprocess
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import server
+import pytest
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    server.SESSION_DIR = tmp_path
+    def fake_run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
+        Path(cmd[-1]).write_bytes(b"audio")
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+    return server.app.test_client()
+
+def test_transcribe_success(client, monkeypatch):
+    monkeypatch.setattr(server.transcriber, "transcribe", lambda p: "hello")
+    data = {"file": (io.BytesIO(b"data"), "video.webm")}
+    resp = client.post("/transcribe", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"text": "hello"}
+
+def test_upload_success(client, monkeypatch):
+    monkeypatch.setattr(server.transcriber, "transcribe", lambda p: "chunk")
+    data = {"file": (io.BytesIO(b"data"), "chunk.webm")}
+    resp = client.post("/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"text": "chunk"}
+
+def test_status_latest(client, tmp_path):
+    text_file = tmp_path / "transcript.txt"
+    text_file.write_text("one\ntwo\n", encoding="utf-8")
+    server.SESSION_DIR = tmp_path
+    resp = client.get("/status/latest")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"text": "two"}
+
+def test_transcribe_whisper_unavailable(client, monkeypatch):
+    monkeypatch.setattr(server.transcriber, "transcribe", lambda p: None)
+    data = {"file": (io.BytesIO(b"data"), "video.webm")}
+    resp = client.post("/transcribe", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 500
+    assert "error" in resp.get_json()


### PR DESCRIPTION
## Summary
- add `/status/latest` API endpoint
- provide pytest-based tests for server routes
- document how to run tests
- include pytest in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729de73738832a95fb8671c0c72d47