### PR TITLE
Implement session status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
 
+### Session Status
+
+When `/transcribe` finishes processing the uploaded recording it writes a
+`status.json` file to the session directory with `{whisper_done: true,
+gpt_done: false}`. A background GPT worker later writes `summary.json` and
+updates the status file to `{whisper_done: true, gpt_done: true}`. You can
+query `/status/latest` to retrieve this status along with the summary and next
+question if they are available.
+
 ## Contribution Guidelines
 
 Contributions are welcome! To contribute:

--- a/server.py
+++ b/server.py
@@ -123,6 +123,8 @@ def transcribe_route():
             if new_tags:
                 existing.extend(new_tags)
                 tags_path.write_text(json.dumps(existing), encoding="utf-8")
+        # Mark Whisper transcription as done
+        session_manager.write_status(str(SESSION_DIR), True, False)
     except Exception as exc:
         logger.exception("Transcription failed: %s", exc)
         return jsonify({"error": f"transcription failed: {exc}"}), 500
@@ -180,6 +182,45 @@ def upload_chunk():
             return jsonify({"error": f"transcription failed: {exc}"}), 500
 
     return jsonify({"text": text})
+
+
+@app.route("/status/latest", methods=["GET"])
+def latest_status():
+    """Return status and summary info for the most recent session."""
+    session_path = session_manager.get_latest_session()
+    if not session_path:
+        return jsonify({"error": "no session available"}), 404
+
+    session_dir = Path(session_path)
+    status_path = session_dir / "status.json"
+    summary_path = session_dir / "summary.json"
+
+    status_data = {}
+    summary_data = {}
+
+    if status_path.exists():
+        try:
+            status_data = json.loads(status_path.read_text(encoding="utf-8") or "{}")
+        except Exception as exc:
+            logger.exception("Failed to read status file: %s", exc)
+
+    if summary_path.exists():
+        try:
+            summary_data = json.loads(summary_path.read_text(encoding="utf-8") or "{}")
+        except Exception as exc:
+            logger.exception("Failed to read summary file: %s", exc)
+
+    response = {
+        "session": session_dir.name,
+        "status": status_data,
+    }
+    if summary_data:
+        if "summary" in summary_data:
+            response["summary"] = summary_data["summary"]
+        if "next_question" in summary_data:
+            response["next_question"] = summary_data["next_question"]
+
+    return jsonify(response)
 
 if __name__ == "__main__":
     app.run(debug=FLASK_DEBUG)

--- a/src/assistant/__init__.py
+++ b/src/assistant/__init__.py
@@ -1,0 +1,6 @@
+"""Assistant package exposing core classes and utilities."""
+
+from .core import Assistant
+from .gpt_worker import generate_summary
+
+__all__ = ["Assistant", "generate_summary"]

--- a/src/assistant/gpt_worker.py
+++ b/src/assistant/gpt_worker.py
@@ -1,0 +1,62 @@
+"""Simple GPT worker placeholder.
+
+This module emulates a background process that reads the latest transcript
+for a session, generates a trivial "summary" and "next question", writes the
+results to ``summary.json`` and updates ``status.json`` via ``SessionManager``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import logging
+
+from src.sessions import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+def generate_summary(session_dir: str, manager: SessionManager | None = None) -> None:
+    """Generate a naive summary for ``session_dir``.
+
+    Parameters
+    ----------
+    session_dir:
+        Path to the session directory.
+    manager:
+        Optional ``SessionManager`` instance used to update status. If not
+        provided a default ``SessionManager`` pointing to the parent directory
+        of ``session_dir`` is created.
+    """
+
+    session = Path(session_dir)
+    if manager is None:
+        manager = SessionManager(session.parent.as_posix())
+
+    transcript_path = session / "transcript.txt"
+    summary_path = session / "summary.json"
+
+    try:
+        text = transcript_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        logger.exception("Failed to read transcript %s: %s", transcript_path, exc)
+        return
+
+    # Very naive summary: first 100 characters
+    summary = text.strip().replace("\n", " ")[:100]
+    next_question = "What would you like to discuss next?"
+    data = {"summary": summary, "next_question": next_question}
+
+    try:
+        summary_path.write_text(json.dumps(data), encoding="utf-8")
+        logger.info("Wrote summary to %s", summary_path)
+    except Exception as exc:
+        logger.exception("Failed to write summary file %s: %s", summary_path, exc)
+        return
+
+    # Update session status
+    try:
+        manager.write_status(session.as_posix(), True, True)
+    except Exception as exc:
+        logger.exception("Failed to update status for %s: %s", session, exc)
+


### PR DESCRIPTION
## Summary
- manage new session files `status.json` and `summary.json`
- expose `generate_summary()` helper for GPT worker
- write status after finishing transcription
- add `/status/latest` endpoint
- document session status endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729df54c0c832aaefbec99e359871f