### PR TITLE
Add docs for GPT-4 summary workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gesahni aims to provide a simple interface for converting audio to text using [W
 - Python 3.8 or later
 - [Whisper](https://github.com/openai/whisper) (optional for transcription)
 - `ffmpeg` (required by Whisper for audio processing)
+- `openai` (for GPT-4 summarization)
 
 ## Running the Application
 
@@ -29,8 +30,16 @@ The script will output the transcribed text to the console.
 ## Configuration
 
 Runtime options are stored in `config.yaml`. The file includes settings for
-audio recording parameters, the Whisper model to load, and the directory used
-for session data. Adjust these values to customize how the assistant operates.
+audio recording parameters, the Whisper model to load, GPT-4 analysis options,
+and the directory used for session data. Adjust these values to customize how
+the assistant operates.
+
+Key options include:
+
+- `whisper_model` – which Whisper model to load for transcription
+- `analysis_model` – GPT-4 model name used for summarization
+- `session_root` – directory where session folders are created
+- `flask_debug` – enable or disable Flask debug mode
 
 ### Web Interface
 
@@ -48,6 +57,29 @@ Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are
 ### Live Streaming
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
+
+### Automatic GPT-4 Analysis
+
+After the full recording is processed, the transcript is analyzed with GPT-4. The
+resulting summary is written to `summary.json` inside the session folder. A
+separate `status.json` file tracks the state of the current transcription and
+analysis.
+
+You can query the latest analysis with:
+
+```bash
+curl http://localhost:5000/status/latest
+```
+
+Example response:
+
+```json
+{
+  "transcript": "...", 
+  "summary": "Key points and actions",
+  "status": "complete"
+}
+```
 
 ## Contribution Guidelines
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,14 @@ audio:
 # Whisper model used for transcription
 whisper_model: base
 
+# GPT-4 model used for analysis
+analysis_model: gpt-4
+
 # Directory where session data is stored
 session_root: sessions
 
 # Flask debug mode
 flask_debug: false
+
+# File tracking the current processing status
+status_file: status.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyyaml
+openai


### PR DESCRIPTION
## Summary
- document new automatic GPT‑4 analysis in README
- add new config options and show status API usage
- list `openai` dependency
- include example `/status/latest` output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68729dfba2d0832a896afbac3cfa8f24