### PR TITLE
Enable real-time streaming via SocketIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gesahni aims to provide a simple interface for converting audio to text using [W
 - Python 3.8 or later
 - [Whisper](https://github.com/openai/whisper) (optional for transcription)
 - `ffmpeg` (required by Whisper for audio processing)
+- `Flask-SocketIO` for real-time streaming
 
 ## Running the Application
 
@@ -34,7 +35,7 @@ for session data. Adjust these values to customize how the assistant operates.
 
 ### Web Interface
 
-The project also includes a minimal web interface for recording video with audio.
+The project also includes a minimal web interface for recording video with audio. It uses WebSockets to stream audio chunks for live transcription.
 Run the Flask server and open `http://localhost:5000` in a browser:
 
 ```bash
@@ -43,11 +44,11 @@ python server.py
 
 The page displays the live camera feed with **Start** and **Stop** buttons. After stopping, the recording is offered as `video.webm` for download. You may also send the captured audio to the backend for transcription (if Whisper is installed) using the **Send Audio** button.
 
-Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are appended to `video.webm`; once the final clip is sent, the server produces `audio.wav`, appends the transcription to `transcript.txt`, and stores any comma-separated tags into `tags.json`.
+Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are appended to `video.webm`; once the final clip is sent, the server produces `audio.wav`, appends the transcription to `transcript.txt`, and stores any comma-separated tags into `tags.json`. When the transcription of the final clip completes, the server emits a `final_transcript` event to the browser.
 
 ### Live Streaming
 
-While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
+While recording, the application streams short WebM chunks to the server over a WebSocket connection. Each chunk is transcribed server-side and the resulting text is pushed back to the browser in real time, updating the text beneath the video element.
 
 ## Contribution Guidelines
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyyaml
+flask-socketio

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, render_template
+from flask_socketio import SocketIO, emit
 import logging
 import tempfile
 import subprocess
@@ -56,6 +57,7 @@ def _cleanup_tmpdir() -> None:
 atexit.register(_cleanup_tmpdir)
 
 app = Flask(__name__)
+socketio = SocketIO(app, cors_allowed_origins="*")
 
 @app.route("/")
 def index():
@@ -110,6 +112,7 @@ def transcribe_route():
         with open(transcript_path, "a", encoding="utf-8") as tf:
             tf.write(text + "\n")
         logger.info("Transcription complete for %s", file.filename)
+        socketio.emit("final_transcript", {"text": text})
 
         if tags:
             try:
@@ -129,9 +132,10 @@ def transcribe_route():
 
     return jsonify({"text": text})
 
-@app.route("/upload", methods=["POST"])
-def upload_chunk():
-    """Handle streaming WebM chunks from the browser."""
+
+@socketio.on("chunk")
+def handle_chunk(data: bytes) -> None:
+    """Process a streaming video chunk sent over WebSocket."""
     global SESSION_DIR
     try:
         new_path = Path(session_manager.create_today_session())
@@ -140,14 +144,6 @@ def upload_chunk():
     except Exception as exc:
         logger.exception("Failed to ensure session directory: %s", exc)
 
-    if "file" not in request.files:
-        logger.warning("No file provided in chunk upload")
-        return jsonify({"error": "missing file"}), 400
-
-    file = request.files["file"]
-    logger.info("Received chunk %s", file.filename)
-
-    data = file.read()
     session_video = SESSION_DIR / "video.webm"
     try:
         with open(session_video, "ab") as dest:
@@ -169,17 +165,18 @@ def upload_chunk():
             )
         except Exception as exc:
             logger.exception("Failed to process chunk: %s", exc)
-            return jsonify({"error": f"processing failed: {exc}"}), 500
-
+            emit("transcription", {"error": str(exc)})
+            return
         try:
             text = transcriber.transcribe(str(audio_path))
             if text is None:
                 raise RuntimeError("transcription returned None")
         except Exception as exc:
             logger.exception("Chunk transcription failed: %s", exc)
-            return jsonify({"error": f"transcription failed: {exc}"}), 500
+            emit("transcription", {"error": str(exc)})
+            return
+    emit("transcription", {"text": text})
 
-    return jsonify({"text": text})
 
 if __name__ == "__main__":
-    app.run(debug=FLASK_DEBUG)
+    socketio.run(app, debug=FLASK_DEBUG)

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,11 +19,22 @@
 <pre id="live-text"></pre>
 <div id="download"></div>
 <pre id="result"></pre>
+<script src="https://cdn.socket.io/4.7.4/socket.io.min.js"></script>
 <script>
 let stream;
 let recorder;
 let chunks = [];
 let liveEl = document.getElementById('live-text');
+const socket = io();
+
+socket.on('transcription', data => {
+    if (data.text) liveEl.textContent += data.text + ' ';
+});
+
+socket.on('final_transcript', data => {
+    const resultEl = document.getElementById('result');
+    if (data.text) resultEl.textContent = `\u2713 Transcript ready\n${data.text}`;
+});
 
 async function init() {
     try {
@@ -65,12 +76,7 @@ function handleChunk(e) {
 }
 
 function sendChunk(blob) {
-    const form = new FormData();
-    form.append('file', blob, 'chunk.webm');
-    fetch('/upload', { method: 'POST', body: form })
-        .then(r => r.json())
-        .then(data => { if (data.text) liveEl.textContent += data.text + ' '; })
-        .catch(err => console.error(err));
+    socket.emit('chunk', blob);
 }
 
 function sendAudio(blob) {
@@ -85,8 +91,8 @@ function sendAudio(blob) {
             resultEl.textContent = 'Transcribing…';
             return r.json();
         })
-        .then(data => {
-            resultEl.textContent = `✓ Transcript ready\n${data.text || data.error}`;
+        .then(() => {
+            resultEl.textContent = '✓ Uploaded';
         })
         .catch(err => {
             resultEl.textContent = err;


### PR DESCRIPTION
## Summary
- add `flask-socketio` dependency
- stream video chunks through a WebSocket connection
- update client to emit chunks via SocketIO and handle live transcripts
- send final transcript events and document the new workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6872a027fa38832a887c8518360342d1