### PR TITLE
Add vector search memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gesahni aims to provide a simple interface for converting audio to text using [W
 - Python 3.8 or later
 - [Whisper](https://github.com/openai/whisper) (optional for transcription)
 - `ffmpeg` (required by Whisper for audio processing)
+- `chromadb` and `sentence-transformers` for vector search persistence
 
 ## Running the Application
 
@@ -48,6 +49,17 @@ Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are
 ### Live Streaming
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
+
+### Querying Stored Transcripts
+
+All transcriptions are embedded and stored in a persistent vector database. Run
+the Flask server and query previous transcripts using the `/search` endpoint:
+
+```bash
+curl "http://localhost:5000/search?q=your+query"
+```
+
+The endpoint returns the most similar stored texts as a JSON list.
 
 ## Contribution Guidelines
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 pyyaml
+chromadb
+sentence-transformers

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ import shutil
 
 from src.sessions import SessionManager
 from src.transcription.base import TranscriptionService
+from src.memory.memory import Memory
 
 def load_config(path: str) -> dict:
     try:
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 config = load_config("config.yaml")
 transcriber = TranscriptionService(config.get("whisper_model", "base"))
 session_manager = SessionManager(config.get("session_root", "sessions"))
+memory = Memory()
 
 # Flask debug mode configuration
 FLASK_DEBUG = bool(config.get("flask_debug", False))
@@ -60,6 +62,18 @@ app = Flask(__name__)
 @app.route("/")
 def index():
     return render_template("index.html")
+
+@app.route("/search")
+def search_route():
+    query = request.args.get("q", "")
+    if not query:
+        return jsonify({"error": "missing query"}), 400
+    try:
+        results = memory.search(query)
+    except Exception as exc:
+        logger.exception("Search failed: %s", exc)
+        return jsonify({"error": f"search failed: {exc}"}), 500
+    return jsonify({"results": results})
 
 @app.route("/transcribe", methods=["POST"])
 def transcribe_route():
@@ -110,6 +124,10 @@ def transcribe_route():
         with open(transcript_path, "a", encoding="utf-8") as tf:
             tf.write(text + "\n")
         logger.info("Transcription complete for %s", file.filename)
+        try:
+            memory.add(text)
+        except Exception as exc:
+            logger.warning("Failed to store transcript in memory: %s", exc)
 
         if tags:
             try:
@@ -175,6 +193,10 @@ def upload_chunk():
             text = transcriber.transcribe(str(audio_path))
             if text is None:
                 raise RuntimeError("transcription returned None")
+            try:
+                memory.add(text)
+            except Exception as exc:
+                logger.warning("Failed to store transcript in memory: %s", exc)
         except Exception as exc:
             logger.exception("Chunk transcription failed: %s", exc)
             return jsonify({"error": f"transcription failed: {exc}"}), 500

--- a/src/memory/memory.py
+++ b/src/memory/memory.py
@@ -1,10 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import chromadb
+from chromadb.config import Settings
+from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+
+
 class Memory:
-    """Simple in-memory storage."""
-    def __init__(self):
-        self._data = []
+    """Persistent vector store for transcripts."""
 
-    def add(self, item: str) -> None:
-        self._data.append(item)
+    def __init__(self, persist_directory: str = "vector_store") -> None:
+        Path(persist_directory).mkdir(parents=True, exist_ok=True)
+        self.client = chromadb.PersistentClient(path=persist_directory)
+        embedding_fn = SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        self.collection = self.client.get_or_create_collection(
+            "transcripts", embedding_function=embedding_fn
+        )
 
-    def get_all(self):
-        return list(self._data)
+    def add(self, text: str) -> None:
+        """Embed and store a text entry."""
+        doc_id = str(uuid4())
+        self.collection.add(documents=[text], ids=[doc_id])
+
+    def search(self, query: str, top_k: int = 5) -> list[str]:
+        """Search stored texts using semantic similarity."""
+        result = self.collection.query(query_texts=[query], n_results=top_k)
+        return result.get("documents", [[]])[0]


### PR DESCRIPTION
## Summary
- add `chromadb` vector store for transcript memory
- embed transcripts and expose search endpoint
- document new features and requirements

## Testing
- `python -m py_compile src/memory/memory.py src/assistant/core.py server.py`
- `pip install chromadb sentence-transformers` *(failed: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6872a051ab24832a9c5c9d9e561cef8d