### PR TITLE
Add diarization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Gesahni aims to provide a simple interface for converting audio to text using [W
 - Python 3.8 or later
 - [Whisper](https://github.com/openai/whisper) (optional for transcription)
 - `ffmpeg` (required by Whisper for audio processing)
+- [pyannote.audio](https://github.com/pyannote/pyannote-audio) (optional for speaker diarization)
 
 ## Running the Application
 
@@ -31,6 +32,8 @@ The script will output the transcribed text to the console.
 Runtime options are stored in `config.yaml`. The file includes settings for
 audio recording parameters, the Whisper model to load, and the directory used
 for session data. Adjust these values to customize how the assistant operates.
+Setting `enable_diarization` to `true` will load the pyannote diarization
+pipeline so that transcripts include speaker labels.
 
 ### Web Interface
 
@@ -45,9 +48,13 @@ The page displays the live camera feed with **Start** and **Stop** buttons. Afte
 
 Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are appended to `video.webm`; once the final clip is sent, the server produces `audio.wav`, appends the transcription to `transcript.txt`, and stores any comma-separated tags into `tags.json`.
 
+If diarization is enabled, lines in `transcript.txt` will be prefixed with the detected speaker label.
+
 ### Live Streaming
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
+
+When diarization is enabled the live transcripts and final `transcript.txt` will include speaker names provided by the diarization model.
 
 ## Contribution Guidelines
 

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@ audio:
 
 # Whisper model used for transcription
 whisper_model: base
+# Enable speaker diarization using pyannote.audio
+enable_diarization: false
 
 # Directory where session data is stored
 session_root: sessions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyyaml
+pyannote.audio

--- a/server.py
+++ b/server.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 
 # ---- Config and Transcriber setup ----
 config = load_config("config.yaml")
-transcriber = TranscriptionService(config.get("whisper_model", "base"))
+transcriber = TranscriptionService(
+    config.get("whisper_model", "base"),
+    enable_diarization=bool(config.get("enable_diarization", False)),
+)
 session_manager = SessionManager(config.get("session_root", "sessions"))
 
 # Flask debug mode configuration

--- a/src/transcription/diarization.py
+++ b/src/transcription/diarization.py
@@ -1,0 +1,77 @@
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .base import TranscriptionService
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pyannote.audio import Pipeline  # type: ignore
+except Exception:  # pragma: no cover - pyannote.audio optional
+    Pipeline = None
+
+
+class DiarizationService:
+    """Perform speaker diarization and return speaker-labelled text."""
+
+    def __init__(self, transcriber: TranscriptionService, model_name: str = "pyannote/speaker-diarization") -> None:
+        self.transcriber = transcriber
+        if Pipeline is not None:
+            try:
+                self.pipeline = Pipeline.from_pretrained(model_name)
+                logger.info("Loaded diarization model '%s'", model_name)
+            except Exception as exc:  # pragma: no cover - external models
+                logger.exception("Failed to load diarization model: %s", exc)
+                self.pipeline = None
+        else:  # pragma: no cover - pyannote not installed
+            self.pipeline = None
+
+    def diarize(self, audio_path: str) -> Optional[str]:
+        """Return speaker-labelled transcription for ``audio_path``."""
+        if self.pipeline is None:
+            logger.warning("Diarization requested but model is unavailable")
+            return None
+        try:
+            diarization = self.pipeline(audio_path)
+        except Exception as exc:
+            logger.exception("Diarization failed: %s", exc)
+            return None
+
+        segments: List[str] = []
+        for turn, _, speaker in diarization.itertracks(yield_label=True):
+            text = self._transcribe_segment(audio_path, turn.start, turn.end)
+            if text:
+                segments.append(f"{speaker}: {text.strip()}")
+        return "\n".join(segments)
+
+    def _transcribe_segment(self, audio_path: str, start: float, end: float) -> Optional[str]:
+        """Helper to transcribe a slice of audio using the parent transcriber."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_name = tmp.name
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    audio_path,
+                    "-ss",
+                    str(start),
+                    "-to",
+                    str(end),
+                    tmp_name,
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            text = self.transcriber._transcribe_no_diarization(tmp_name)
+        except Exception as exc:  # pragma: no cover - ffmpeg or transcription errors
+            logger.exception("Failed to transcribe segment: %s", exc)
+            text = None
+        finally:
+            Path(tmp_name).unlink(missing_ok=True)
+        return text


### PR DESCRIPTION
## Summary
- add optional pyannote-based diarization service
- update TranscriptionService to call diarization pipeline
- expose diarization toggle via `config.yaml` and server
- document speaker segmentation and new dependency

## Testing
- `python -m py_compile src/transcription/base.py src/transcription/diarization.py server.py main.py src/assistant/core.py src/memory/memory.py src/sessions/manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6872a069c020832a8097da08f65c62d5