### PR TITLE
Add optional noise gate to recording interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Uploaded recordings are stored under `sessions/YYYY-MM-DD/`. Incoming chunks are
 
 While recording, the application now uploads short WebM chunks to `/upload`. Each chunk is transcribed on the server and the text is shown live beneath the video element.
 
+### Optional Noise Gate
+
+The web interface offers a **Noise gate** checkbox. When enabled, the audio
+stream passes through a Web Audio `DynamicsCompressorNode` configured as a
+simple gate before being recorded. No additional libraries are required.
+
 ## Contribution Guidelines
 
 Contributions are welcome! To contribute:

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,11 +11,12 @@
 <body>
 <h1>Live Camera Feed</h1>
 <video id="video" autoplay playsinline></video>
-<div>
-    <button id="start">Start</button>
-    <button id="stop" disabled>Stop</button>
-    <input id="tags" placeholder="tags" />
-</div>
+    <div>
+        <button id="start">Start</button>
+        <button id="stop" disabled>Stop</button>
+        <input id="tags" placeholder="tags" />
+        <label><input type="checkbox" id="use-filter" /> Noise gate</label>
+    </div>
 <pre id="live-text"></pre>
 <div id="download"></div>
 <pre id="result"></pre>
@@ -24,6 +25,28 @@ let stream;
 let recorder;
 let chunks = [];
 let liveEl = document.getElementById('live-text');
+let audioCtx;
+
+function createFilteredStream() {
+    if (!document.getElementById('use-filter').checked) {
+        return stream;
+    }
+    audioCtx = new AudioContext();
+    const source = audioCtx.createMediaStreamSource(stream);
+    const gate = audioCtx.createDynamicsCompressor();
+    gate.threshold.value = -50;
+    gate.knee.value = 40;
+    gate.ratio.value = 12;
+    gate.attack.value = 0;
+    gate.release.value = 0.25;
+    const dest = audioCtx.createMediaStreamDestination();
+    source.connect(gate);
+    gate.connect(dest);
+    return new MediaStream([
+        ...stream.getVideoTracks(),
+        ...dest.stream.getAudioTracks()
+    ]);
+}
 
 async function init() {
     try {
@@ -39,7 +62,9 @@ init();
 document.getElementById('start').onclick = () => {
     chunks = [];
     liveEl.textContent = '';
-    recorder = new MediaRecorder(stream);
+    const procStream = createFilteredStream();
+    document.getElementById('video').srcObject = procStream;
+    recorder = new MediaRecorder(procStream);
     recorder.ondataavailable = handleChunk;
     recorder.onstop = handleStop;
     recorder.start(2000); // collect 2s chunks
@@ -49,6 +74,11 @@ document.getElementById('start').onclick = () => {
 
 document.getElementById('stop').onclick = () => {
     recorder.stop();
+    if (audioCtx) {
+        audioCtx.close();
+        audioCtx = null;
+    }
+    document.getElementById('video').srcObject = stream;
     document.getElementById('stop').disabled = true;
 };
 


### PR DESCRIPTION
## Summary
- add a noise gate checkbox in the web UI
- pipe audio through a DynamicsCompressorNode when enabled
- connect processed stream to MediaRecorder
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872a06c6400832a8b368d3a29eb2d58