### PR TITLE
Add env template and expand config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+PICOVOICE_KEY=your-picovoice-key
+AES_MASTER_KEY=your-aes-master-key
+TUSD_URL=http://tusd:1080/files/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ var/
 .zip
 Archive.zip
 node_modules/
+.env

--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,17 @@ flask_debug: false
 
 # File tracking the current processing status
 status_file: status.json
+
+# Media base directories
+media:
+  uploads: uploads
+  sessions: sessions
+
+# Redis connection
+redis_url: redis://localhost:6379/0
+
+# InsightFace API endpoint
+insightface_endpoint: http://localhost:18080
+
+# TTS engine choice (piper or voicevox)
+tts_engine: piper


### PR DESCRIPTION
## Summary
- ignore `.env` files
- add `.env.example` template
- expand `config.yaml` with media paths and services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f8c9c9c4832aafa66bc4cbdae7e4