### PR TITLE
Add enrollment tables and Pydantic schemas

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Boolean
+from sqlalchemy import Column, DateTime, ForeignKey, String, Boolean, LargeBinary
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, relationship
 
@@ -19,6 +19,11 @@ class User(Base):
 
     voice_samples = relationship("VoiceSample", back_populates="user")
     face_samples = relationship("FaceSample", back_populates="user")
+    enrollment_status = relationship(
+        "EnrollmentStatus", back_populates="user", uselist=False
+    )
+    voiceprints = relationship("VoicePrint", back_populates="user")
+    faceprints = relationship("FacePrint", back_populates="user")
 
 class VoiceSample(Base):
     __tablename__ = "voice_samples"
@@ -41,3 +46,39 @@ class FaceSample(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     user = relationship("User", back_populates="face_samples")
+
+
+class EnrollmentStatus(Base):
+    __tablename__ = "enrollment_statuses"
+
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), primary_key=True)
+    voice_done = Column(Boolean, default=False)
+    face_done = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    user = relationship("User", back_populates="enrollment_status")
+
+
+class VoicePrint(Base):
+    __tablename__ = "voiceprints"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    vector = Column(LargeBinary)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="voiceprints")
+
+
+class FacePrint(Base):
+    __tablename__ = "faceprints"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    vector = Column(LargeBinary)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="faceprints")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+from datetime import datetime
+from pydantic import BaseModel
+
+class EnrollInitResponse(BaseModel):
+    user_id: UUID
+
+class VoiceRequest(BaseModel):
+    user_id: UUID
+    voiceprint: bytes
+
+class FaceRequest(BaseModel):
+    user_id: UUID
+    faceprint: bytes
+
+class StatusResponse(BaseModel):
+    user_id: UUID
+    voice_done: bool
+    face_done: bool
+    created_at: datetime | None = None
+    updated_at: datetime | None = None


### PR DESCRIPTION
## Summary
- expand `User` model with related enrollment fields
- add new models for `EnrollmentStatus`, `VoicePrint`, and `FacePrint`
- create `schemas.py` with enrollment request/response models

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873f8d30864832aac0799eb181fb25e