### PR TITLE
Add enrollment API endpoints and encryption helper

### DIFF
--- a/app/routes/enroll.py
+++ b/app/routes/enroll.py
@@ -1,14 +1,21 @@
 import os
+import uuid
 from pathlib import Path
 from fastapi import APIRouter, File, UploadFile, HTTPException, Depends
 from fastapi import BackgroundTasks
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
+import requests
 
 from ..database import get_session
 from ..models import User, VoiceSample, FaceSample
 from ..utils.crypto import encrypt_file
-from ..utils.whisper_worker import transcribe_voice
+from ..utils.whisper_worker import (
+    transcribe_voice,
+    speaker_job,
+    face_job,
+)
+from ..utils.encryption import encrypt_bytes, decrypt_bytes
 
 import numpy as np
 import face_recognition
@@ -17,11 +24,24 @@ router = APIRouter()
 
 MEDIA_ROOT = Path('media')
 EMBED_ROOT = Path('embeddings')
+UPLOAD_ROOT = Path('uploads')
+VOICE_ROOT = UPLOAD_ROOT / 'voice'
+FACE_ROOT = UPLOAD_ROOT / 'face'
 
 class Prefs(BaseModel):
     name: str | None = None
     greeting: str | None = None
     reminder_type: str | None = None
+
+
+class VoiceRequest(BaseModel):
+    user_id: str
+    tus_url: str
+
+
+class FaceRequest(BaseModel):
+    user_id: str
+    urls: list[str]
 
 @router.post('/voice/{user_id}')
 async def enroll_voice(user_id: str, file: UploadFile = File(...), db: Session = Depends(get_session)):
@@ -104,3 +124,94 @@ async def complete_enroll(user_id: str, db: Session = Depends(get_session)):
     # stub call to external TTS service
     audio_url = f"https://example.com/greet_{user_id}.mp3"
     return {"audio_url": audio_url}
+
+
+@router.post('/init')
+async def enroll_init(db: Session = Depends(get_session)):
+    """Create a new user and prepare upload folders."""
+    user_id = str(uuid.uuid4())
+    (VOICE_ROOT / user_id).mkdir(parents=True, exist_ok=True)
+    (FACE_ROOT / user_id).mkdir(parents=True, exist_ok=True)
+    user = User(id=user_id)
+    db.add(user)
+    db.commit()
+    return {"user_id": user_id}
+
+
+@router.post('/voice')
+async def upload_voice(payload: VoiceRequest, db: Session = Depends(get_session)):
+    """Fetch encrypted audio from TUS URL, decrypt, store and enqueue job."""
+    user = db.query(User).filter_by(id=payload.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail='user not found')
+    voice_dir = VOICE_ROOT / payload.user_id
+    voice_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        resp = requests.get(payload.tus_url, timeout=10)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f'failed to fetch audio: {exc}')
+    enc_path = voice_dir / 'voice.enc'
+    enc_path.write_bytes(resp.content)
+    dec_data = decrypt_bytes(resp.content)
+    wav_path = voice_dir / 'voice.wav'
+    wav_path.write_bytes(dec_data)
+    sample = VoiceSample(user_id=payload.user_id, file_path=str(enc_path))
+    db.add(sample)
+    db.commit()
+    speaker_job.delay(str(wav_path), payload.user_id)
+    return {"message": "queued"}
+
+
+@router.post('/face')
+async def upload_face(payload: FaceRequest, db: Session = Depends(get_session)):
+    """Fetch face images, encrypt them and enqueue processing job."""
+    if len(payload.urls) != 3:
+        raise HTTPException(status_code=400, detail='expected three urls')
+    user = db.query(User).filter_by(id=payload.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail='user not found')
+    face_dir = FACE_ROOT / payload.user_id
+    face_dir.mkdir(parents=True, exist_ok=True)
+    names = ['front', 'left', 'right']
+    enc_paths = []
+    for name, url in zip(names, payload.urls):
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f'failed to fetch {name}: {exc}')
+        enc_data = encrypt_bytes(resp.content)
+        path = face_dir / f'{name}.enc'
+        path.write_bytes(enc_data)
+        enc_paths.append(str(path))
+    sample = FaceSample(user_id=payload.user_id,
+                        front_path=enc_paths[0],
+                        left_path=enc_paths[1],
+                        right_path=enc_paths[2],
+                        embeddings_path='')
+    db.add(sample)
+    db.commit()
+    face_job.delay(enc_paths, payload.user_id)
+    return {"message": "queued"}
+
+
+@router.get('/status/{user_id}')
+async def enroll_status(user_id: str, db: Session = Depends(get_session)):
+    user = db.query(User).filter_by(id=user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail='user not found')
+    voice = db.query(VoiceSample).filter_by(user_id=user_id).first()
+    face = db.query(FaceSample).filter_by(user_id=user_id).first()
+    percent = 0
+    if voice:
+        percent += 50
+    if face:
+        percent += 50
+    status = 'pending'
+    if percent > 0:
+        status = 'processing'
+    if user.is_active:
+        status = 'complete'
+        percent = 100
+    return {"status": status, "percent": percent}

--- a/app/utils/encryption.py
+++ b/app/utils/encryption.py
@@ -1,0 +1,15 @@
+import os
+from cryptography.fernet import Fernet
+
+FERNET_KEY = os.getenv("FERNET_KEY", Fernet.generate_key())
+fernet = Fernet(FERNET_KEY)
+
+
+def encrypt_bytes(data: bytes) -> bytes:
+    """Encrypt raw bytes using Fernet."""
+    return fernet.encrypt(data)
+
+
+def decrypt_bytes(data: bytes) -> bytes:
+    """Decrypt raw bytes using Fernet."""
+    return fernet.decrypt(data)

--- a/app/utils/whisper_worker.py
+++ b/app/utils/whisper_worker.py
@@ -9,6 +9,7 @@ from ..database import SessionLocal
 from ..models import VoiceSample
 from .crypto import decrypt_file
 
+
 celery_app = Celery(
     'whisper_worker',
     broker=os.getenv('CELERY_BROKER', 'redis://redis:6379/0'),
@@ -39,3 +40,17 @@ def transcribe_voice(file_path: str, user_id: str) -> None:
             sample.transcript_path = str(txt_path)
             db.commit()
     temp_path.unlink(missing_ok=True)
+
+
+@celery_app.task
+def speaker_job(file_path: str, user_id: str) -> None:
+    """Placeholder task for speaker enrollment."""
+    # Actual speaker model training would happen here
+    return None
+
+
+@celery_app.task
+def face_job(file_paths: list[str], user_id: str) -> None:
+    """Placeholder task for face enrollment."""
+    # Face embedding and storage would happen here
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ redis
 face_recognition
 numpy
 openai-whisper
+requests


### PR DESCRIPTION
## Summary
- add simple Fernet encryption helper
- extend whisper worker with speaker and face job placeholders
- implement enrollment init, voice, face, and status APIs
- add requests dependency

## Testing
- `python -m py_compile app/routes/enroll.py app/utils/whisper_worker.py app/utils/encryption.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_6873f8ded470832a9f7f7f4dba1c10b6