### PR TITLE
Add worker enrollment tasks

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Boolean
+from sqlalchemy import Column, DateTime, ForeignKey, String, Boolean, LargeBinary
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, relationship
 
@@ -19,6 +19,8 @@ class User(Base):
 
     voice_samples = relationship("VoiceSample", back_populates="user")
     face_samples = relationship("FaceSample", back_populates="user")
+    voiceprints = relationship("VoicePrint", back_populates="user")
+    faceprints = relationship("FacePrint", back_populates="user")
 
 class VoiceSample(Base):
     __tablename__ = "voice_samples"
@@ -41,3 +43,23 @@ class FaceSample(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     user = relationship("User", back_populates="face_samples")
+
+
+class VoicePrint(Base):
+    __tablename__ = "voiceprints"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    vector = Column(LargeBinary)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="voiceprints")
+
+
+class FacePrint(Base):
+    __tablename__ = "faceprints"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    vector = Column(LargeBinary)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="faceprints")

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /worker
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir pv_eagle_python openai-whisper
+COPY . .
+CMD ["celery", "-A", "worker.tasks.celery_app", "worker", "--loglevel=info"]

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -1,0 +1,87 @@
+import os
+import uuid
+from pathlib import Path
+from typing import List
+
+import requests
+import numpy as np
+from celery import Celery
+
+from app.utils.crypto import decrypt_file
+from app.database import SessionLocal
+from app.models import VoicePrint, FacePrint
+
+try:
+    from pv_eagle_python import Eagle
+except Exception:  # pragma: no cover - library may be missing in tests
+    Eagle = None
+
+API_BASE = os.getenv("API_BASE", "http://api:8000")
+celery_app = Celery(
+    "worker",
+    broker=os.getenv("CELERY_BROKER", "redis://redis:6379/0"),
+    backend=os.getenv("CELERY_BACKEND", "redis://redis:6379/0"),
+)
+
+
+def _post_callback(path: str, payload: dict) -> None:
+    """Send a POST request to ``API_BASE``/``path`` ignoring failures."""
+    url = f"{API_BASE}{path}"
+    try:
+        requests.post(url, json=payload, timeout=10)
+    except Exception:
+        pass
+
+
+@celery_app.task
+def speaker_job(user_id: str, tus_url: str) -> None:
+    """Enroll a speaker from a remote encrypted WAV file."""
+    tmp_enc = Path("/tmp") / f"{uuid.uuid4()}.wav.enc"
+    tmp_wav = tmp_enc.with_suffix(".wav")
+    try:
+        resp = requests.get(tus_url, timeout=30)
+        resp.raise_for_status()
+        tmp_enc.write_bytes(resp.content)
+        decrypt_file(str(tmp_enc), str(tmp_wav))
+        if Eagle is None:
+            raise RuntimeError("pv_eagle_python not available")
+        eagle = Eagle()
+        vector: bytes = eagle.enroll(str(tmp_wav))
+        with SessionLocal() as db:
+            vp = VoicePrint(user_id=user_id, vector=vector)
+            db.add(vp)
+            db.commit()
+    finally:
+        tmp_enc.unlink(missing_ok=True)
+        tmp_wav.unlink(missing_ok=True)
+    _post_callback("/internal/voice_done", {"user_id": user_id})
+
+
+@celery_app.task
+def face_job(user_id: str, tus_urls: List[str]) -> None:
+    """Enroll a face from multiple encrypted images."""
+    vectors = []
+    for url in tus_urls:
+        tmp_enc = Path("/tmp") / f"{uuid.uuid4()}.jpg.enc"
+        tmp_img = tmp_enc.with_suffix(".jpg")
+        try:
+            resp = requests.get(url, timeout=30)
+            resp.raise_for_status()
+            tmp_enc.write_bytes(resp.content)
+            decrypt_file(str(tmp_enc), str(tmp_img))
+            with open(tmp_img, "rb") as fh:
+                r = requests.post(f"{API_BASE}/embed", files={"file": fh}, timeout=30)
+            r.raise_for_status()
+            data = r.json()
+            embedding = np.array(data.get("vector") or data.get("embedding"), dtype=np.float32)
+            vectors.append(embedding)
+        finally:
+            tmp_enc.unlink(missing_ok=True)
+            tmp_img.unlink(missing_ok=True)
+    if vectors:
+        avg = np.mean(vectors, axis=0)
+        with SessionLocal() as db:
+            fp = FacePrint(user_id=user_id, vector=avg.tobytes())
+            db.add(fp)
+            db.commit()
+    _post_callback("/internal/face_done", {"user_id": user_id})


### PR DESCRIPTION
## Summary
- add Celery tasks for speaker and face enrollment
- add models for storing voice and face prints
- install Picovoice and Whisper libs for worker image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f8ea5fa4832a8a09307dfe9680e0