### PR TITLE
Fix crypto imports and optional encryption

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -26,7 +26,7 @@ class User(Base):
 class VoiceSample(Base):
     __tablename__ = "voice_samples"
     id              = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id         = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id         = Column(String, ForeignKey("users.id"))
     file_path       = Column(String)
     transcript_path = Column(String, nullable=True)
     created_at      = Column(DateTime, default=datetime.utcnow)
@@ -36,7 +36,7 @@ class VoiceSample(Base):
 class FaceSample(Base):
     __tablename__ = "face_samples"
     id               = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id          = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id          = Column(String, ForeignKey("users.id"))
     left_path        = Column(String)
     right_path       = Column(String)
     front_path       = Column(String)
@@ -53,7 +53,7 @@ class ConsentLog(Base):
 
 class EnrollmentStatus(Base):
     __tablename__ = "enrollment_statuses"
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"), primary_key=True)
+    user_id    = Column(String, ForeignKey("users.id"), primary_key=True)
     voice_done = Column(Boolean, default=False)
     face_done  = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.utcnow)
@@ -64,7 +64,7 @@ class EnrollmentStatus(Base):
 class VoicePrint(Base):
     __tablename__ = "voiceprints"
     id         = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id    = Column(String, ForeignKey("users.id"))
     vector     = Column(LargeBinary)
     created_at = Column(DateTime, default=datetime.utcnow)
 
@@ -73,7 +73,7 @@ class VoicePrint(Base):
 class FacePrint(Base):
     __tablename__ = "faceprints"
     id         = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id    = Column(String, ForeignKey("users.id"))
     vector     = Column(LargeBinary)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/app/routes/enroll.py
+++ b/app/routes/enroll.py
@@ -8,7 +8,7 @@ import requests
 
 from ..database import get_session
 from ..models import User, VoiceSample, FaceSample
-from ..utils.crypto import encrypt_file
+from ..utils.encryption import encrypt_file
 from ..utils.whisper_worker import (
     transcribe_voice,
     speaker_job,

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -7,7 +7,7 @@ import requests
 import numpy as np
 from celery import Celery
 
-from app.utils.crypto import decrypt_file
+from app.utils.encryption import decrypt_file
 from app.database import SessionLocal
 from app.models import VoicePrint, FacePrint
 


### PR DESCRIPTION
## Summary
- make cryptography optional in encryption utilities
- switch modules to use new encryption import
- relax user ID types in SQLAlchemy models to support plain strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874529b89b8832aab3beaa49da7a568