### PR TITLE
Improve session utilities and add tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import uuid
 
 from sqlalchemy import Column, DateTime, ForeignKey, String, Boolean, LargeBinary
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, relationship
 
 class Base(DeclarativeBase):
@@ -10,7 +9,7 @@ class Base(DeclarativeBase):
 
 class User(Base):
     __tablename__ = "users"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=True)
     greeting = Column(String, nullable=True)
     reminder_type = Column(String, nullable=True)
@@ -25,8 +24,8 @@ class User(Base):
 
 class VoiceSample(Base):
     __tablename__ = "voice_samples"
-    id              = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id         = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    id              = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id         = Column(String, ForeignKey("users.id"))
     file_path       = Column(String)
     transcript_path = Column(String, nullable=True)
     created_at      = Column(DateTime, default=datetime.utcnow)
@@ -35,8 +34,8 @@ class VoiceSample(Base):
 
 class FaceSample(Base):
     __tablename__ = "face_samples"
-    id               = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id          = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    id               = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id          = Column(String, ForeignKey("users.id"))
     left_path        = Column(String)
     right_path       = Column(String)
     front_path       = Column(String)
@@ -47,13 +46,13 @@ class FaceSample(Base):
 
 class ConsentLog(Base):
     __tablename__ = "consent_log"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     user_agent = Column(String, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
 class EnrollmentStatus(Base):
     __tablename__ = "enrollment_statuses"
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"), primary_key=True)
+    user_id    = Column(String, ForeignKey("users.id"), primary_key=True)
     voice_done = Column(Boolean, default=False)
     face_done  = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.utcnow)
@@ -63,8 +62,8 @@ class EnrollmentStatus(Base):
 
 class VoicePrint(Base):
     __tablename__ = "voiceprints"
-    id         = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    id         = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id    = Column(String, ForeignKey("users.id"))
     vector     = Column(LargeBinary)
     created_at = Column(DateTime, default=datetime.utcnow)
 
@@ -72,8 +71,8 @@ class VoicePrint(Base):
 
 class FacePrint(Base):
     __tablename__ = "faceprints"
-    id         = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id    = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+    id         = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id    = Column(String, ForeignKey("users.id"))
     vector     = Column(LargeBinary)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/app/utils/crypto.py
+++ b/app/utils/crypto.py
@@ -1,0 +1,13 @@
+from .encryption import (
+    encrypt_file,
+    decrypt_file,
+    encrypt_bytes,
+    decrypt_bytes,
+)
+
+__all__ = [
+    "encrypt_file",
+    "decrypt_file",
+    "encrypt_bytes",
+    "decrypt_bytes",
+]

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -68,4 +68,7 @@ class SessionManager:
                 json.dump(data, fh)
         except Exception as exc:
             logger.exception("Failed to write status file %s: %s", path, exc)
+            raise
+
+        return None
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.memory.memory import Memory
+
+
+def test_memory_add_and_search(tmp_path):
+    mem = Memory(persist_directory=tmp_path.as_posix())
+    mem.add("hello world")
+    mem.add("another entry")
+    results = mem.search("hello", top_k=1)
+    assert results == ["hello world"]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.sessions import SessionManager
+
+
+def test_create_today_session_creates_files(tmp_path):
+    manager = SessionManager(tmp_path.as_posix())
+    session_dir = Path(manager.create_today_session())
+    assert session_dir.is_dir()
+    assert session_dir.name == date.today().isoformat()
+    expected_files = [
+        "video.webm",
+        "audio.wav",
+        "transcript.txt",
+        "tags.json",
+        "status.json",
+        "summary.json",
+    ]
+    for name in expected_files:
+        assert (session_dir / name).exists()
+
+
+def test_get_latest_session_returns_most_recent(tmp_path):
+    manager = SessionManager(tmp_path.as_posix())
+    old_dir = tmp_path / "2020-01-01"
+    new_dir = tmp_path / "2023-01-01"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    assert manager.get_latest_session() == new_dir.as_posix()


### PR DESCRIPTION
## Summary
- add fallback crypto module
- switch database models to use string IDs for SQLite
- handle missing AESGCM in encryption helpers
- fix SessionManager.write_status
- add tests for Memory and SessionManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687452a6fd54832ab5e5d72c97f700be