### PR TITLE
Add worker task tests and fix enrollment UUID handling

### DIFF
--- a/app/routes/enroll.py
+++ b/app/routes/enroll.py
@@ -46,13 +46,14 @@ class FaceRequest(BaseModel):
 
 @router.post('/voice/{user_id}')
 async def enroll_voice(
-    user_id: str, file: UploadFile | None = File(None), db: Session = Depends(get_session)
+    user_id: str, file: UploadFile | None = File(None), db: Session = Depends(get_session),
 ):
+    uid = uuid.UUID(user_id)
     if file is None:
         raise HTTPException(status_code=400, detail='missing file')
     if file.content_type != 'audio/wav':
         raise HTTPException(status_code=400, detail='invalid file')
-    if db.query(VoiceSample).filter_by(user_id=user_id).first():
+    if db.query(VoiceSample).filter_by(user_id=uid).first():
         raise HTTPException(status_code=409, detail='already enrolled')
     user_dir = MEDIA_ROOT / user_id
     user_dir.mkdir(parents=True, exist_ok=True)
@@ -62,10 +63,10 @@ async def enroll_voice(
         fh.write(data)
     enc_path = raw_path.with_suffix('.enc')
     encrypt_file(str(raw_path), str(enc_path))
-    voice_sample = VoiceSample(user_id=user_id, file_path=str(enc_path))
+    voice_sample = VoiceSample(user_id=uid, file_path=str(enc_path))
     db.add(voice_sample)
     db.commit()
-    transcribe_voice.delay(str(enc_path), user_id)
+    transcribe_voice.delay(str(enc_path), str(uid))
     return {"message": "queued"}
 
 @router.post('/face/{user_id}')

--- a/worker/tests/test_tasks.py
+++ b/worker/tests/test_tasks.py
@@ -1,10 +1,15 @@
 from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import importlib
 import pytest
 
 from app import models, database
+
+import types
+sys.modules.setdefault("whisper", types.ModuleType("whisper"))
 from app.utils import whisper_worker
 
 @pytest.fixture()
@@ -33,16 +38,128 @@ def test_transcribe_voice_updates_sample(setup_db, tmp_path, monkeypatch):
     monkeypatch.setattr(whisper_worker, "get_model", lambda: DummyModel())
     monkeypatch.chdir(tmp_path)
 
+    user_id = uuid.uuid4()
     with database.SessionLocal() as db:
-        db.add(models.VoiceSample(user_id="u1", file_path=str(voice)))
+        db.add(models.VoiceSample(user_id=user_id, file_path=str(voice)))
         db.commit()
 
-    whisper_worker.transcribe_voice(str(voice), "u1")
+    whisper_worker.transcribe_voice(str(voice), user_id)
 
-    out = Path("transcripts/u1.txt")
+    out = Path(f"transcripts/{user_id}.txt")
     assert out.exists()
     assert out.read_text() == "hi"
     with database.SessionLocal() as db:
-        sample = db.query(models.VoiceSample).filter_by(user_id="u1").first()
+        sample = db.query(models.VoiceSample).filter_by(user_id=user_id).first()
         assert sample.transcript_path == str(out)
+
+import sys
+import types
+import uuid
+import numpy as np
+
+
+@pytest.fixture()
+def worker_tasks(tmp_path, monkeypatch):
+    # stub crypto module
+    crypto = types.ModuleType("crypto")
+    def fake_decrypt(src, dest):
+        Path(dest).write_bytes(Path(src).read_bytes())
+    crypto.decrypt_file = fake_decrypt
+    sys.modules["app.utils.crypto"] = crypto
+
+    # stub pv_eagle_python
+    pv = types.ModuleType("pv_eagle_python")
+    class DummyEagle:
+        def enroll(self, path):
+            return b"vec"
+    pv.Eagle = DummyEagle
+    sys.modules["pv_eagle_python"] = pv
+
+    engine = create_engine(f"sqlite:///{tmp_path}/worker.sqlite")
+    SessionLocal = sessionmaker(bind=engine)
+    monkeypatch.setattr(database, "engine", engine)
+    monkeypatch.setattr(database, "SessionLocal", SessionLocal)
+    models.Base.metadata.create_all(bind=engine)
+
+    import importlib
+    import worker.tasks as tasks
+    tasks = importlib.reload(tasks)
+    return tasks
+
+
+def test_speaker_job_creates_voiceprint(worker_tasks, monkeypatch):
+    tasks = worker_tasks
+    user_id = uuid.uuid4()
+    uid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    monkeypatch.setattr(tasks.uuid, "uuid4", lambda: uid)
+
+    class Resp:
+        def __init__(self, content=b"data"):
+            self.content = content
+        def raise_for_status(self):
+            pass
+    monkeypatch.setattr(tasks.requests, "get", lambda *a, **k: Resp())
+
+    cb = {}
+    monkeypatch.setattr(tasks, "_post_callback", lambda path, payload: cb.update({"path": path, "payload": payload}))
+
+    class DummyEagle:
+        def enroll(self, path):
+            return b"voicevec"
+    monkeypatch.setattr(tasks, "Eagle", DummyEagle)
+
+    tasks.speaker_job(user_id, "http://tus")
+
+    enc = Path("/tmp") / f"{uid}.wav.enc"
+    dec = Path("/tmp") / f"{uid}.wav"
+    assert not enc.exists()
+    assert not dec.exists()
+    with tasks.SessionLocal() as db:
+        vp = db.query(models.VoicePrint).filter_by(user_id=user_id).first()
+        assert vp is not None
+        assert vp.vector == b"voicevec"
+    assert cb == {"path": "/internal/voice_done", "payload": {"user_id": user_id}}
+
+
+def test_face_job_creates_faceprint(worker_tasks, monkeypatch):
+    tasks = worker_tasks
+    user_id = uuid.uuid4()
+    ids = [
+        uuid.UUID("22222222-2222-2222-2222-222222222221"),
+        uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        uuid.UUID("22222222-2222-2222-2222-222222222223"),
+    ]
+    gen = (i for i in ids)
+    monkeypatch.setattr(tasks.uuid, "uuid4", lambda: next(gen))
+
+    class GetResp:
+        def __init__(self):
+            self.content = b"img"
+        def raise_for_status(self):
+            pass
+    monkeypatch.setattr(tasks.requests, "get", lambda *a, **k: GetResp())
+
+    class PostResp:
+        def __init__(self):
+            self._json = {"vector": [1.0, 2.0, 3.0]}
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return self._json
+    monkeypatch.setattr(tasks.requests, "post", lambda *a, **k: PostResp())
+
+    cb = {}
+    monkeypatch.setattr(tasks, "_post_callback", lambda path, payload: cb.update({"path": path, "payload": payload}))
+
+    tasks.face_job(user_id, ["a", "b", "c"])
+
+    for uid in ids:
+        assert not (Path("/tmp") / f"{uid}.jpg.enc").exists()
+        assert not (Path("/tmp") / f"{uid}.jpg").exists()
+    with tasks.SessionLocal() as db:
+        fp = db.query(models.FacePrint).filter_by(user_id=user_id).first()
+        assert fp is not None
+        vec = np.frombuffer(fp.vector, dtype=np.float32)
+        assert np.allclose(vec, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    assert cb == {"path": "/internal/face_done", "payload": {"user_id": user_id}}
 


### PR DESCRIPTION
## Summary
- add fixture and new tests for worker tasks verifying voice and face job behaviour
- create crypto stub in FastAPI tests
- adjust FastAPI tests to use UUID values
- fix enroll route to parse UUIDs correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745c908438832a813debf6bbb3b910