### PR TITLE
Add useRecorder hook tests

### DIFF
--- a/frontend/src/__tests__/useRecorder.test.ts
+++ b/frontend/src/__tests__/useRecorder.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import useRecorder from '../hooks/useRecorder'
+
+class MockMediaRecorder {
+  ondataavailable: ((e: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  start = vi.fn()
+  stop = vi.fn(() => {
+    this.ondataavailable?.({ data: new Blob(['a']) })
+    this.onstop?.()
+  })
+  constructor(_stream: MediaStream) {}
+}
+
+describe('useRecorder', () => {
+  const origGetUserMedia = navigator.mediaDevices?.getUserMedia
+  const origMediaRecorder = (global as any).MediaRecorder
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getUserMedia: vi.fn(() => Promise.resolve({} as any)) },
+      configurable: true
+    })
+    ;(global as any).MediaRecorder = MockMediaRecorder as any
+  })
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getUserMedia: origGetUserMedia },
+      configurable: true
+    })
+    ;(global as any).MediaRecorder = origMediaRecorder
+    vi.restoreAllMocks()
+  })
+
+  it('start sets isRecording', async () => {
+    const { result } = renderHook(() => useRecorder())
+    await act(async () => {
+      await result.current.start()
+    })
+    expect(result.current.isRecording).toBe(true)
+  })
+
+  it('stop resolves with an audio blob', async () => {
+    const { result } = renderHook(() => useRecorder())
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      result.current.stop()
+    })
+    await waitFor(() => {
+      expect(result.current.audioBlob).toBeInstanceOf(Blob)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `useRecorder`

## Testing
- `npx vitest run`
- `PYTHONPATH=/workspace/Gesahni:/tmp/stubs pytest fastapi-api/tests/test_enroll.py worker/tests/test_tasks.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68745c91ca04832a817123cc14cc6156