### PR TITLE
Add voice AI dashboard and auth API

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ class User(Base):
     __tablename__ = "users"
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=True)
+    email = Column(String, nullable=True, unique=True)
     greeting = Column(String, nullable=True)
     reminder_type = Column(String, nullable=True)
     is_active = Column(Boolean, default=False)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,26 @@
+from uuid import uuid4
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from ..schemas import RegisterRequest, LoginRequest
+
+from ..database import get_session
+from ..models import User, EnrollmentStatus
+from ..utils.session import create_session
+
+router = APIRouter()
+
+@router.post('/register')
+def register(payload: RegisterRequest, db: Session = Depends(get_session)):
+    user = User(id=str(uuid4()), name=payload.name, email=payload.email)
+    db.add(user)
+    db.add(EnrollmentStatus(user_id=user.id))
+    db.commit()
+    return {"user_id": user.id}
+
+@router.post('/login')
+def login(payload: LoginRequest, db: Session = Depends(get_session)):
+    user = db.query(User).filter_by(id=payload.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail='user not found')
+    token = create_session(user.id)
+    return {"token": token}

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..database import get_session
+from ..models import User
+
+router = APIRouter()
+
+@router.get('/{user_id}/enrollment-status')
+def enrollment_status(user_id: str, db: Session = Depends(get_session)):
+    user = db.query(User).filter_by(id=user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail='user not found')
+    enrolled = bool(user.is_active)
+    return {"enrolled": enrolled}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -19,3 +19,12 @@ class StatusResponse(BaseModel):
     face_done: bool
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+
+class RegisterRequest(BaseModel):
+    name: str | None = None
+    email: str | None = None
+
+
+class LoginRequest(BaseModel):
+    user_id: str

--- a/app/utils/session.py
+++ b/app/utils/session.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import uuid
+from typing import Optional, Dict
+
+_session_store: Dict[str, str] = {}
+
+
+def create_session(user_id: str) -> str:
+    token = str(uuid.uuid4())
+    _session_store[token] = user_id
+    return token
+
+
+def get_user(token: str) -> Optional[str]:
+    return _session_store.get(token)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import VoiceEnroll  from './screens/VoiceEnroll'
 import FaceCapture  from './screens/FaceCapture'
 import PrefSetup    from './screens/PrefSetup'
 import Finish       from './screens/Finish'
+import VoiceAI      from './screens/VoiceAI'
 
 export default function App() {
   return (
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="/face"  element={<FaceCapture />} />
         <Route path="/prefs" element={<PrefSetup />} />
         <Route path="/finish" element={<Finish />} />
+        <Route path="/voice-ai" element={<VoiceAI />} />
       </Routes>
     </EnrollProvider>
   )

--- a/frontend/src/screens/VoiceAI.tsx
+++ b/frontend/src/screens/VoiceAI.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react'
+import { io, Socket } from 'socket.io-client'
+
+export default function VoiceAI() {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [messages, setMessages] = useState<string[]>([])
+  const [recording, setRecording] = useState(false)
+  const socketRef = useRef<Socket>()
+  const mediaRef = useRef<MediaRecorder>()
+
+  useEffect(() => {
+    async function init() {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+      if (videoRef.current) videoRef.current.srcObject = stream
+      mediaRef.current = new MediaRecorder(stream, { mimeType: 'video/webm' })
+      mediaRef.current.ondataavailable = e => {
+        if (socketRef.current && e.data.size > 0) {
+          socketRef.current.emit('chunk', e.data)
+        }
+      }
+    }
+    init()
+  }, [])
+
+  function start() {
+    if (!mediaRef.current) return
+    socketRef.current = io()
+    socketRef.current.on('transcription', (d: { text: string }) => {
+      setMessages(prev => [...prev, d.text])
+    })
+    mediaRef.current.start(1000)
+    setRecording(true)
+  }
+
+  function stop() {
+    mediaRef.current?.stop()
+    socketRef.current?.disconnect()
+    setRecording(false)
+  }
+
+  return (
+    <div className="p-4 h-screen flex">
+      <div className="flex-1">
+        <video ref={videoRef} autoPlay playsInline className="w-full h-full object-cover" />
+      </div>
+      <div className="flex-1 flex flex-col space-y-2 p-4">
+        <div className="flex-1 overflow-y-auto border p-2">
+          {messages.map((m, i) => <div key={i}>{m}</div>)}
+        </div>
+        <div className="space-y-2">
+          <button onClick={recording ? stop : start} className="px-2 py-1 bg-blue-500 text-white rounded w-full">
+            {recording ? 'Stop Listening' : 'Start Listening'}
+          </button>
+          <button className="px-2 py-1 bg-green-500 text-white rounded w-full">Play my Gospel Playlist</button>
+          <button className="px-2 py-1 bg-green-500 text-white rounded w-full">What did I watch yesterday?</button>
+          <button className="px-2 py-1 bg-green-500 text-white rounded w-full">Set Reminder</button>
+          <button className="px-2 py-1 bg-green-500 text-white rounded w-full">TV Controls</button>
+          <button className="px-2 py-1 bg-green-500 text-white rounded w-full">Journal</button>
+          <button className="px-2 py-1 bg-red-500 text-white rounded w-full">Log Out</button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement FastAPI session management and authentication routes
- expose user enrollment-status endpoint
- extend `User` model with email address
- create React VoiceAI dashboard screen
- wire up new route and socket.io dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875300b5d3c832aa62fcaf8c62c5b26