### PR TITLE
Add env substitution support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,10 +29,10 @@ media:
   sessions: sessions
 
 # Redis connection
-redis_url: redis://localhost:6379/0
+redis_url: ${REDIS_URL}
 
 # InsightFace API endpoint
-insightface_endpoint: http://localhost:18080
+insightface_endpoint: ${INSIGHTFACE_ENDPOINT}
 
 # TTS engine choice (piper or voicevox)
 tts_engine: piper

--- a/main.py
+++ b/main.py
@@ -2,18 +2,22 @@
 import argparse
 import logging
 import yaml
+import os
+from dotenv import load_dotenv
+from pathlib import Path
 from src.assistant.core import Assistant
 from src.sessions import SessionManager
 
 logger = logging.getLogger(__name__)
 
 def load_config(path: str) -> dict:
-    """Load YAML configuration from ``path``.
-    Returns an empty dictionary if loading fails.
-    """
+    """Load YAML configuration and substitute environment variables."""
+    env_file = Path(path).with_name(".env")
+    load_dotenv(env_file)
     try:
-        with open(path, 'r', encoding='utf-8') as fh:
-            return yaml.safe_load(fh) or {}
+        text = Path(path).read_text(encoding="utf-8")
+        text = os.path.expandvars(text)
+        return yaml.safe_load(text) or {}
     except Exception as exc:
         logger.exception("Failed to load configuration: %s", exc)
         return {}

--- a/server.py
+++ b/server.py
@@ -8,6 +8,8 @@ import yaml
 import json
 import atexit
 import shutil
+import os
+from dotenv import load_dotenv
 
 from src.sessions import SessionManager
 from src.transcription.base import TranscriptionService
@@ -15,9 +17,13 @@ from src.memory.memory import Memory
 from src.assistant.chat import ChatAssistant
 
 def load_config(path: str) -> dict:
+    """Load YAML configuration and substitute environment variables."""
+    env_file = Path(path).with_name(".env")
+    load_dotenv(env_file)
     try:
-        with open(path, "r", encoding="utf-8") as fh:
-            return yaml.safe_load(fh) or {}
+        text = Path(path).read_text(encoding="utf-8")
+        text = os.path.expandvars(text)
+        return yaml.safe_load(text) or {}
     except Exception as exc:
         logger = logging.getLogger(__name__)
         logger.exception("Failed to load config: %s", exc)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from main import load_config
+
+
+def test_env_substitution(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    cfg_file = tmp_path / "config.yaml"
+    env_file.write_text("DATABASE_URL=sqlite:///test.db\n", encoding="utf-8")
+    cfg_file.write_text("db_url: ${DATABASE_URL}\n", encoding="utf-8")
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    cfg = load_config(str(cfg_file))
+    assert cfg["db_url"] == "sqlite:///test.db"


### PR DESCRIPTION
## Summary
- allow environment variable expansion in configuration files
- update default config to use `${REDIS_URL}` and `${INSIGHTFACE_ENDPOINT}`
- add regression test for config loading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687722ca731c832a990fcad6755ab7d7