### PR TITLE
Backend reads DATABASE_URL from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Key options include:
 - `analysis_model` – GPT-4 model name used for summarization
 - `session_root` – directory where session folders are created
 - `flask_debug` – enable or disable Flask debug mode
+- `database_url` – Postgres connection string
 
 ### Web Interface
 

--- a/app/database.py
+++ b/app/database.py
@@ -1,8 +1,23 @@
 import os
+import yaml
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://postgres:postgres@db/postgres")
+
+def _load_config_url() -> str | None:
+    """Return ``database_url`` from config.yaml if available."""
+    config_path = os.getenv("CONFIG_PATH", "config.yaml")
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            config = yaml.safe_load(fh) or {}
+        return config.get("database_url")
+    except Exception:
+        return None
+
+
+DATABASE_URL = os.getenv("DATABASE_URL") or _load_config_url() or (
+    "postgresql+psycopg2://postgres:postgres@db/postgres"
+)
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,9 @@ session_root: sessions
 # Flask debug mode
 flask_debug: false
 
+# Database connection string
+database_url: postgresql+psycopg2://postgres:postgres@db/postgres
+
 # File tracking the current processing status
 status_file: status.json
 


### PR DESCRIPTION
## Summary
- connect to database using `DATABASE_URL` from environment or `config.yaml`
- add `database_url` to `config.yaml`
- document new setting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687722e7133c832ab952af92f969451c