### PR TITLE
Fix CORS for local development

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,10 @@ from fastapi import Request
 
 app = FastAPI()
 
-origins = ["http://localhost:5173"]
+# Allow requests from the frontend and the API service itself during
+# local development. The frontend typically runs on port 5174 while the
+# FastAPI backend runs on port 8000.
+origins = ["http://localhost:5174", "http://localhost:8000"]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- allow requests from both the frontend on port 5174 and the API on port 8000

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687723099ba0832abcd138aedbbfc22b