### PR TITLE
Add Flower dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Docker Compose is provided for local development:
 docker-compose up --build
 ```
 
+Once running, a Flower dashboard for Celery is available at
+`http://localhost:5555`.
+
 The React frontend can be started separately:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,18 @@ services:
     networks:
       - backend
 
+  flower:
+    image: mher/flower:latest
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - FLOWER_PORT=5555
+    depends_on:
+      - redis
+    networks:
+      - backend
+    ports:
+      - "5555:5555"
+
 volumes:
   uploads:
   sessions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,3 +147,5 @@ wsproto==1.2.0
 yarl==1.20.1
 zipp==3.23.0
 zstandard==0.23.0
+celery==5.3.6
+flower==2.0.1


### PR DESCRIPTION
## Summary
- expose Celery monitoring with Flower in `docker-compose`
- document Flower URL in README
- install `celery` and `flower` via requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772326c8fc832abaac958bab0dcdd3